### PR TITLE
remove preventDefault on window mouseup & mousemove events

### DIFF
--- a/src/utils/EventManager.ts
+++ b/src/utils/EventManager.ts
@@ -57,11 +57,9 @@ module n3Charts.Utils {
       // replace each others' listeners, but is a timestamp really unique ?
       let id = new Date().getTime();
       d3.select(window).on('mouseup.' + id, () => {
-        (<Event>d3.event).preventDefault();
         this.trigger('window-mouseup')
       });
       d3.select(window).on('mousemove.' + id, () => {
-        (<Event>d3.event).preventDefault();
         this.trigger('window-mousemove')
       });
 


### PR DESCRIPTION
these statements are trapping mouse events, which is the reason we can't select text anywhere on the page.  Removing them doesn't appear to hurt the behavior of the charts at all.
