### PR TITLE
Random escape characters

### DIFF
--- a/src/styles/_legend.scss
+++ b/src/styles/_legend.scss
@@ -44,19 +44,11 @@
     }
 
     &.dashed-line > .icon {
-      @include svg("
-        <g style=\"stroke: white; fill: none; stroke-dasharray: 4px,2px;\">
-          <path d='M0,6 L10,6'/>
-        </g>
-      ");
+      @include svg("<g style=\"stroke: white; fill: none; stroke-dasharray: 4px,2px;\"><path d='M0,6 L10,6'/></g>");
     }
 
     &.line > .icon {
-      @include svg("
-        <g style=\"stroke: white;\">
-          <path d='M0,6 L10,6'/>
-        </g>
-      ");
+      @include svg("<g style=\"stroke: white;\"><path d='M0,6 L10,6'/></g>");
     }
 
     &.area > .icon {


### PR DESCRIPTION
These newlines create escape characters in the compiled css `\a` which causes unexpected behavior. IE dash style meltdowns.